### PR TITLE
Use reusable workflows for Terraform

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -10,48 +10,14 @@ on:
       - "environments/prod/configuration/values.yaml"
       - "terraform/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
-  terraform:
-    name: "Terraform Apply"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@v4
-
-      - name: Get Token From GitHub APP
-        id: get_token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.UNIR_TFM_APP_ID }}
-          private-key: ${{ secrets.UNIR_TFM_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - name: "Configure AWS credentials"
-        uses: aws-actions/configure-aws-credentials@v4.2.1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
-          aws-region: us-east-1
-
-      - name: "Setup Terraform"
-        uses: hashicorp/setup-terraform@v3
-
-      - name: "Terraform Format Check"
-        working-directory: terraform
-        run: terraform fmt -check
-
-      - name: "Terraform Init"
-        working-directory: terraform
-        run: terraform init -input=false
-
-      - name: "Terraform Validate"
-        working-directory: terraform
-        run: terraform validate
-
-      - name: "Terraform Plan"
-        working-directory: terraform
-        run: terraform plan -input=false
-
-      - name: "Terraform Apply"
-        working-directory: terraform
-        run: terraform apply -auto-approve -input=false
+  apply-changes:
+    name: "Apply Changes"
+    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/terraform-apply-aws.yml@main
+    with:
+      working_directory: terraform
+    secrets: inherit

--- a/.github/workflows/terraform-destroy.yaml
+++ b/.github/workflows/terraform-destroy.yaml
@@ -3,33 +3,14 @@ name: "Destroy ArgoCD Applications"
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
-  destroy:
-    name: "Terraform Destroy"
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@v4
-
-      - name: "Configure AWS credentials"
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
-          aws-region: us-east-1
-
-      - name: "Setup Terraform"
-        uses: hashicorp/setup-terraform@v3
-
-      - name: "Terraform Init"
-        working-directory: terraform
-        run: terraform init -input=false
-
-      - name: "Terraform Validate"
-        working-directory: terraform
-        run: terraform validate
-
-      - name: "Terraform Destroy"
-        working-directory: terraform
-        run: terraform destroy -auto-approve -input=false
+  destroy-resources:
+    name: "Destroy Resources"
+    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/terraform-destroy-aws.yml@main
+    with:
+      working_directory: terraform
+    secrets: inherit

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -10,53 +10,14 @@ on:
       - "environments/prod/configuration/values.yaml"
       - "terraform/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
-  terraform:
-    name: "Terraform Plan"
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@v4
-
-      - name: Get Token From GitHub APP
-        id: get_token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.UNIR_TFM_APP_ID }}
-          private-key: ${{ secrets.UNIR_TFM_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - name: "Configure AWS credentials"
-        uses: aws-actions/configure-aws-credentials@v4.2.1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
-          aws-region: us-east-1
-
-      - name: "Setup Terraform"
-        uses: hashicorp/setup-terraform@v3
-
-      - name: "Terraform Format Check"
-        working-directory: terraform
-        run: terraform fmt -check
-
-      - name: "Terraform Init"
-        working-directory: terraform
-        run: terraform init -input=false
-
-      - name: "Terraform Validate"
-        working-directory: terraform
-        run: terraform validate
-
-      - name: "Terraform Plan"
-        working-directory: terraform
-        run: terraform plan -out .planfile -input=false
-
-      - name: Post PR comment
-        if: always()
-        uses: borchero/terraform-plan-comment@v2
-        with:
-          token: ${{ steps.get_token.outputs.token }}
-          working-directory: terraform
-          planfile: .planfile
+  plan-changes:
+    name: "Plan Changes"
+    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/terraform-plan-aws.yml@main
+    with:
+      working_directory: terraform
+    secrets: inherit


### PR DESCRIPTION
This pull request refactors the GitHub Actions workflows for Terraform operations (`apply`, `destroy`, and `plan`) by replacing custom job definitions with reusable workflows. It also introduces concurrency controls to ensure that only one instance of each workflow runs at a time for the same branch. 

### Workflow Refactoring:
* [`.github/workflows/terraform-apply.yaml`](diffhunk://#diff-3b9bba76a5ffb1ff5dce644ab6f9f94b4c31bf429c44cd14ad8f40ab0cac9067L13-R23): Replaced custom Terraform `apply` job with a reusable workflow (`terraform-apply-aws.yml`) and added concurrency control to prevent overlapping runs.
* [`.github/workflows/terraform-destroy.yaml`](diffhunk://#diff-530bc4b4a0f81d207c4a26b754de9ff0905e2d9f2a144ade59e7520f8c873438L6-R16): Replaced custom Terraform `destroy` job with a reusable workflow (`terraform-destroy-aws.yml`) and added concurrency control to prevent overlapping runs.
* [`.github/workflows/terraform-plan.yml`](diffhunk://#diff-1ca63e6aac27d170492851d93ed42746d3493ce0db3c6ee7422efa4b7e3f0b6dL13-R23): Replaced custom Terraform `plan` job with a reusable workflow (`terraform-plan-aws.yml`) and added concurrency control to prevent overlapping runs.